### PR TITLE
added check for missing redstone torch for redstone sign

### DIFF
--- a/src/com/Acrobot/ChestShop/Config/Language.java
+++ b/src/com/Acrobot/ChestShop/Config/Language.java
@@ -25,6 +25,10 @@ public enum Language {
     YOU_BOUGHT_FROM_SHOP("You bought %amount %item from %owner for %price."),
     SOMEBODY_BOUGHT_FROM_YOUR_SHOP("%buyer bought %amount %item for %price from you."),
 
+    YOU_ACTIVATED_SIGN("You activated %owner's sign for %price."),
+    SOMEBODY_ACTIVATED_YOUR_SIGN("%buyer activated your sign for %price."),
+    SIGN_NOT_CONNECTED("This shop is missing a redstone torch to activate."),
+
     YOU_SOLD_TO_SHOP("You sold %amount %item to %buyer for %price."),
     SOMEBODY_SOLD_TO_YOUR_SHOP("%seller sold %amount %item for %price to you."),
 

--- a/src/com/Acrobot/ChestShop/Logging/Logging.java
+++ b/src/com/Acrobot/ChestShop/Logging/Logging.java
@@ -36,6 +36,10 @@ public class Logging {
         if (Config.getBoolean(Property.LOG_TO_DATABASE) || Config.getBoolean(Property.GENERATE_STATISTICS_PAGE)) logToDatabase(isBuying, shop, player);
     }
 
+    public static void logActivation(Player player, String owner, float buyPrice) {
+        log(player.getName() + " activated " + owner + "'s sign for " + buyPrice);
+    }
+
     private static void logToDatabase(boolean isBuying, Shop shop, Player player) {
         Transaction transaction = new Transaction();
 

--- a/src/com/Acrobot/ChestShop/Shop/ShopManagement.java
+++ b/src/com/Acrobot/ChestShop/Shop/ShopManagement.java
@@ -1,9 +1,22 @@
 package com.Acrobot.ChestShop.Shop;
 
+import com.Acrobot.ChestShop.ChestShop;
 import com.Acrobot.ChestShop.Chests.MinecraftChest;
+import com.Acrobot.ChestShop.Config.Config;
+import com.Acrobot.ChestShop.Config.Language;
+import com.Acrobot.ChestShop.Config.Property;
+import com.Acrobot.ChestShop.Economy;
 import com.Acrobot.ChestShop.Items.Items;
+import com.Acrobot.ChestShop.Logging.Logging;
+import com.Acrobot.ChestShop.Permission;
 import com.Acrobot.ChestShop.Utils.uBlock;
+import com.Acrobot.ChestShop.Utils.uSign;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.Chest;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
@@ -33,5 +46,111 @@ public class ShopManagement {
         }
         Shop shop = new Shop(chestMc != null ? new MinecraftChest(chestMc) : null, false, sign, item);
         shop.sell(player);
+    }
+
+    public static void activate(Sign sign, Player player) {
+        World world = sign.getWorld();
+        float buyPrice = uSign.buyPrice(sign.getLine(2));
+        String owner = sign.getLine(0);
+        String playerName = player.getName();
+
+        if (buyPrice == -1) {
+            player.sendMessage(Config.getLocal(Language.NO_BUYING_HERE));
+            return;
+        }
+        if (!Permission.has(player, Permission.BUY)) {
+            player.sendMessage(Config.getLocal(Language.NO_PERMISSION));
+            return;
+        }
+
+        if (!Economy.hasEnough(playerName, buyPrice, world)) {
+            player.sendMessage(Config.getLocal(Language.NOT_ENOUGH_MONEY));
+            return;
+        }
+
+        Block attachedBlock = sign.getBlock().getRelative(((org.bukkit.material.Sign) sign.getData()).getAttachedFace());
+
+        if (!HasRedstoneTorch(attachedBlock)) {
+            player.sendMessage(Config.getLocal(Language.SIGN_NOT_CONNECTED));
+            return;
+        }
+
+        String account = getOwnerAccount(owner);
+        if (!account.isEmpty() && Economy.hasAccount(account, world)) Economy.add(account, buyPrice, world);
+
+        Economy.substract(playerName, buyPrice, world);
+
+        String formattedPrice = Economy.formatBalance(buyPrice);
+        if (Config.getBoolean(Property.SHOW_TRANSACTION_INFORMATION_CLIENT)) {
+            player.sendMessage(Config.getLocal(Language.YOU_ACTIVATED_SIGN)
+                    .replace("%owner", owner)
+                    .replace("%price", formattedPrice));
+        }
+
+        Logging.logActivation(player, owner, buyPrice);
+
+        if (Config.getBoolean(Property.SHOW_TRANSACTION_INFORMATION_OWNER)) {
+            sendMessageToOwner(Config.getLocal(Language.SOMEBODY_ACTIVATED_YOUR_SIGN)
+                    .replace("%buyer", playerName)
+                    .replace("%price", formattedPrice), owner);
+        }
+
+        powerSingleAdjacent(attachedBlock);
+    }
+
+    private static void powerSingleAdjacent(Block block) {
+        final BlockFace[] adjacentFaces = {
+                BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN
+        };
+
+        for (BlockFace face : adjacentFaces) {
+            Block adjacentBlock = block.getRelative(face);
+            if (adjacentBlock.getType() == Material.REDSTONE_TORCH_ON){
+                adjacentBlock.setType(Material.AIR);
+
+                Bukkit.getScheduler().scheduleSyncDelayedTask(ChestShop.pm.getPlugin("ChestShop"), () -> {
+                    ReplaceRedstoneTorch(adjacentBlock);
+                }, 8);
+                break;
+            }
+        }
+    }
+
+    private static boolean HasRedstoneTorch(Block block) {
+        final BlockFace[] adjacentFaces = {
+                BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN
+        };
+
+        for (BlockFace face : adjacentFaces) {
+            Block adjacentBlock = block.getRelative(face);
+            if (adjacentBlock.getType() == Material.REDSTONE_TORCH_ON) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static String getOwnerAccount(String owner) {
+        return uSign.isAdminShop(owner) ? Config.getString(Property.SERVER_ECONOMY_ACCOUNT) : owner;
+    }
+
+    private static boolean isAdminShop(String owner) {
+        return uSign.isAdminShop(owner);
+    }
+
+    private static void sendMessageToOwner(String msg, String owner) {
+        if (!isAdminShop(owner)) {
+            Player player = ChestShop.getBukkitServer().getPlayer(owner);
+            if (player != null) {
+                player.sendMessage(msg);
+            }
+        }
+    }
+
+    private static void ReplaceRedstoneTorch(Block block){
+        if (block.getType() == Material.AIR){
+            block.setType(Material.REDSTONE_TORCH_ON);
+        }
     }
 }


### PR DESCRIPTION
Activating a redstone sign will now check that there is something to activate before charging the shopper